### PR TITLE
torch-manager: Add flashlightd support

### DIFF
--- a/src/dbus/meson.build
+++ b/src/dbus/meson.build
@@ -118,3 +118,10 @@ generated_dbus_sources += gnome.gdbus_codegen('phosh-gtk-mountoperation-dbus',
                                               'org.Gtk.MountOperationHandler.xml',
 					      interface_prefix: 'org.Gtk',
 					      namespace: 'PhoshDBus')
+
+# Droidian Flashlightd (org.droidian.Flashlightd)
+generated_dbus_sources += gnome.gdbus_codegen('droidian-flashlightd-dbus',
+					      'org.droidian.Flashlightd.xml',
+					      interface_prefix: 'org.droidian.Flashlightd',
+					      namespace: 'DroidianTorchDbus')
+

--- a/src/dbus/org.droidian.Flashlightd.xml
+++ b/src/dbus/org.droidian.Flashlightd.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+"http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node>
+  <interface name="org.droidian.Flashlightd">
+    <annotation name="org.gtk.GDBus.C.Name" value="DroidianTorch" />
+
+    <property name="Brightness" type="i" access="read"/>
+
+    <method name="SetBrightness">
+      <arg name="brightness" direction="in" type="u" />
+    </method>
+
+  </interface>
+</node>

--- a/src/ui/settings-menu.ui
+++ b/src/ui/settings-menu.ui
@@ -203,7 +203,7 @@
             </child>
             <child>
               <object class="GtkRevealer" id="revealer">
-                <property name="visible">True</property>
+                <property name="visible">False</property>
                 <property name="reveal-child" bind-source="torchinfo" bind-property="enabled" bind-flags="sync-create"/>
                 <child>
                   <object class="GtkBox">


### PR DESCRIPTION
This Pull Request add flashlightd support to torch-manager.
Since we can't manage flashlight brightness level (yet), torch slider visibility has been disabled.
