### PR TITLE
Allow changing phone call volume

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "subprojects/gvc"]
 	path = subprojects/gvc
-	url = https://gitlab.gnome.org/GNOME/libgnome-volume-control.git
+	url = https://github.com/droidian/libgnome-volume-control.git
 [submodule "subprojects/libcall-ui"]
 	path = subprojects/libcall-ui
 	url = https://gitlab.gnome.org/guidog/libcall-ui.git

--- a/meson.build
+++ b/meson.build
@@ -134,6 +134,7 @@ libgvc = subproject('gvc',
     'pkglibdir=' + pkglibdir,
     'static=true',
     'introspection=false',
+    'with-droidian-extensions=true',
     'alsa=false'
   ])
 libgvc_dep = libgvc.get_variable('libgvc_dep')

--- a/src/settings/gvc-channel-bar.c
+++ b/src/settings/gvc-channel-bar.c
@@ -27,8 +27,8 @@
 #include "gvc-mixer-control.h"
 
 #define SCALE_SIZE 128
-#define ADJUSTMENT_MAX_NORMAL gvc_mixer_control_get_vol_max_norm(NULL)
-#define ADJUSTMENT_MAX_AMPLIFIED gvc_mixer_control_get_vol_max_amplified(NULL)
+#define ADJUSTMENT_MAX_NORMAL (gdouble) PA_VOLUME_NORM
+#define ADJUSTMENT_MAX_AMPLIFIED (gdouble) PA_VOLUME_UI_MAX
 #define ADJUSTMENT_MAX (self->is_amplified ? ADJUSTMENT_MAX_AMPLIFIED : ADJUSTMENT_MAX_NORMAL)
 #define SCROLLSTEP (ADJUSTMENT_MAX / 100.0 * 5.0)
 

--- a/src/settings/gvc-channel-bar.c
+++ b/src/settings/gvc-channel-bar.c
@@ -553,3 +553,15 @@ gvc_channel_bar_new (void)
                        NULL);
   return GTK_WIDGET (self);
 }
+
+
+GtkWidget *
+gvc_channel_bar_new_with_icon (const char *icon_name)
+{
+  GObject *self;
+  self = g_object_new (GVC_TYPE_CHANNEL_BAR,
+                       "orientation", GTK_ORIENTATION_HORIZONTAL,
+                       "icon-name", icon_name,
+                       NULL);
+  return GTK_WIDGET (self);
+}

--- a/src/settings/gvc-channel-bar.h
+++ b/src/settings/gvc-channel-bar.h
@@ -18,6 +18,8 @@ G_DECLARE_FINAL_TYPE (GvcChannelBar, gvc_channel_bar, GVC, CHANNEL_BAR, GtkBox)
 
 GtkWidget *         gvc_channel_bar_new                 (void);
 
+GtkWidget *         gvc_channel_bar_new_with_icon       (const char *icon_name);
+
 void                gvc_channel_bar_set_name            (GvcChannelBar *bar,
                                                          const char    *name);
 void                gvc_channel_bar_set_icon_name       (GvcChannelBar *bar,


### PR DESCRIPTION
Part of droidian/meta#2. Please read the whole bugreport for current status and rough edges.

phosh now listens to the Droidian-flavoured gvc's phone-stream-added and phone-stream-removed
signals, and whenever a phone stream is present, the user can now change call volume from
the phosh quick settings popup.

It is implemented using a separate GvcChannelBar, which has its visibility inversely bound to
the standard channel bar's.