### PR TITLE
Allow to disable proximity sensor

### DIFF
--- a/data/mobi.phosh.shell.gschema.xml
+++ b/data/mobi.phosh.shell.gschema.xml
@@ -11,6 +11,16 @@
     </key>
   </schema>
 
+  <schema id="mobi.phosh.shell.proximity" path="/mobi/phosh/shell/proximity/">
+    <key name="enable-proximity-sensor" type="b">
+      <default>true</default>
+      <summary>Turn off the screen during calls when the phone is near your head</summary>
+      <description>
+        Automatically turn off the screen during phone calls when the device is held close to your ear, using the proximity sensor.
+      </description>
+    </key>
+  </schema>
+
   <!-- Legacy schema -->
 
   <schema id="sm.puri.phosh" path="/sm/puri/phosh/">

--- a/src/lockscreen.c
+++ b/src/lockscreen.c
@@ -754,9 +754,22 @@ static void
 on_show (PhoshLockscreen *self, gpointer userdata)
 {
   PhoshLockscreenPrivate *priv;
+  const char *active;
+
   g_return_if_fail (PHOSH_IS_LOCKSCREEN (self));
+
   priv = phosh_lockscreen_get_instance_private (self);
-  phosh_lockscreen_set_page (self, priv->default_page);
+  active = phosh_calls_manager_get_active_call_handle (priv->calls_manager);
+
+  if (active) {
+    guint duration = hdy_deck_get_transition_duration (priv->deck);
+
+    hdy_deck_set_transition_duration (priv->deck, 0);
+    hdy_deck_set_visible_child (priv->deck, GTK_WIDGET (priv->box_call_display));
+    hdy_deck_set_transition_duration (priv->deck, duration);
+  } else {
+    phosh_lockscreen_set_page (self, priv->default_page);
+  }
 }
 
 

--- a/src/proximity.c
+++ b/src/proximity.c
@@ -15,6 +15,8 @@
 #include "sensor-proxy-manager.h"
 #include "util.h"
 
+#include <cui-call.h>
+
 /**
  * PhoshProximity:
  *
@@ -38,10 +40,13 @@ static GParamSpec *props[LAST_PROP];
 typedef struct _PhoshProximity {
   GObject parent;
 
+  gboolean has_proximity;
   gboolean claimed;
   PhoshSensorProxyManager *sensor_proxy_manager;
   PhoshCallsManager *calls_manager;
   PhoshFader *fader;
+
+  GSettings      *settings;
 } PhoshProximity;
 
 G_DEFINE_TYPE (PhoshProximity, phosh_proximity, G_TYPE_OBJECT);
@@ -157,20 +162,26 @@ on_has_proximity_changed (PhoshProximity          *self,
                           GParamSpec              *pspec,
                           PhoshSensorProxyManager *proxy)
 {
-  gboolean has_proximity;
-
-  has_proximity = phosh_dbus_sensor_proxy_get_has_proximity (
+  self->has_proximity = phosh_dbus_sensor_proxy_get_has_proximity (
     PHOSH_DBUS_SENSOR_PROXY (self->sensor_proxy_manager));
 
-  g_debug ("Found %s proximity sensor", has_proximity ? "a" : "no");
+  g_debug ("Found %s proximity sensor", self->has_proximity ? "a" : "no");
 
   /* If the proxy went a way we always unclaim but only claim on ongoing calls: */
-  if (!phosh_calls_manager_get_active_call_handle (self->calls_manager) && has_proximity)
+  if (!phosh_calls_manager_get_active_call_handle (self->calls_manager) && self->has_proximity)
     return;
 
-  phosh_proximity_claim_proximity (self, has_proximity);
+  phosh_proximity_claim_proximity (self, self->has_proximity);
 }
 
+static void
+on_call_state_changed (PhoshProximity *self,
+                       GParamSpec     *pspec,
+                       PhoshCall      *call)
+{
+  if (cui_call_get_state (CUI_CALL (call)) == CUI_CALL_STATE_ACTIVE)
+    phosh_shell_enable_power_save (phosh_shell_get_default (), TRUE);
+}
 
 static void
 on_calls_manager_active_call_changed (PhoshProximity    *self,
@@ -178,12 +189,27 @@ on_calls_manager_active_call_changed (PhoshProximity    *self,
                                       PhoshCallsManager *calls_manager)
 {
   gboolean active;
+  const char *handle;
+  PhoshCall *call;
 
   g_return_if_fail (PHOSH_IS_PROXIMITY (self));
   g_return_if_fail (PHOSH_IS_CALLS_MANAGER (calls_manager));
 
-  active = !!phosh_calls_manager_get_active_call_handle (self->calls_manager);
-  phosh_proximity_claim_proximity (self, active);
+  handle = phosh_calls_manager_get_active_call_handle (self->calls_manager);
+  active = !!handle;
+
+  if (g_settings_get_boolean (self->settings, "enable-proximity-sensor") &&
+      self->has_proximity) {
+    phosh_proximity_claim_proximity (self, active);
+  } else {
+    if (active) {
+      call = phosh_calls_manager_get_call (self->calls_manager, handle);
+      g_signal_connect_swapped (call,
+                                "notify::state",
+                                G_CALLBACK (on_call_state_changed),
+                                self);
+    }
+  }
   /* TODO: if call is over wait until we hit the threshold */
 }
 
@@ -264,6 +290,8 @@ phosh_proximity_constructed (GObject *object)
 {
   PhoshProximity *self = PHOSH_PROXIMITY (object);
 
+  self->settings = g_settings_new (PHOSH_SHELL_PROXIMITY_SCHEMA_ID);
+
   g_signal_connect_swapped (self->calls_manager,
                             "notify::active-call",
                             G_CALLBACK (on_calls_manager_active_call_changed),
@@ -302,6 +330,8 @@ phosh_proximity_dispose (GObject *object)
                                            self);
      g_clear_object (&self->calls_manager);
   }
+
+  g_clear_object (&self->settings);
 
   g_clear_pointer (&self->fader, phosh_cp_widget_destroy);
   G_OBJECT_CLASS (phosh_proximity_parent_class)->dispose (object);
@@ -372,4 +402,10 @@ phosh_proximity_has_fader (PhoshProximity *self)
   g_return_val_if_fail (PHOSH_IS_PROXIMITY (self), FALSE);
 
   return !!self->fader;
+}
+
+gboolean
+phosh_proximity_sensor_enabled (PhoshProximity *self)
+{
+  return self->has_proximity && g_settings_get_boolean (self->settings, "enable-proximity-sensor");
 }

--- a/src/proximity.h
+++ b/src/proximity.h
@@ -9,6 +9,8 @@
 #include "calls-manager.h"
 #include "sensor-proxy-manager.h"
 
+#define PHOSH_SHELL_PROXIMITY_SCHEMA_ID "mobi.phosh.shell.proximity"
+
 G_BEGIN_DECLS
 
 #define PHOSH_TYPE_PROXIMITY (phosh_proximity_get_type ())
@@ -18,5 +20,6 @@ G_DECLARE_FINAL_TYPE (PhoshProximity, phosh_proximity, PHOSH, PROXIMITY, GObject
 PhoshProximity *phosh_proximity_new (PhoshSensorProxyManager *sensor_proxy_manager,
                                      PhoshCallsManager       *calls_manager);
 gboolean        phosh_proximity_has_fader (PhoshProximity *sensor_proxy_manager);
+gboolean        phosh_proximity_sensor_enabled (PhoshProximity *sensor_proxy_manager);
 
 G_END_DECLS

--- a/src/shell.c
+++ b/src/shell.c
@@ -229,14 +229,15 @@ update_top_level_layer (PhoshShell *self)
   PhoshShellPrivate *priv;
   guint32 layer, current;
   gboolean use_top_layer;
-
-  priv = phosh_shell_get_instance_private (self);
+  gboolean proximity_sensor_enabled;
 
   g_return_if_fail (PHOSH_IS_SHELL (self));
   priv = phosh_shell_get_instance_private (self);
 
   if (priv->top_panel == NULL)
     return;
+
+  proximity_sensor_enabled = phosh_proximity_sensor_enabled (priv->proximity);
 
   g_return_if_fail (PHOSH_IS_TOP_PANEL (priv->top_panel));
   state = phosh_shell_get_state (self);
@@ -245,7 +246,9 @@ update_top_level_layer (PhoshShell *self)
      overlay layer since it uses an exclusive zone and hence the fader is
      drawn below that top-panel. This can be dropped once layer-shell allows
      to specify the z-level */
-  use_top_layer = priv->proximity && phosh_proximity_has_fader (priv->proximity);
+  use_top_layer = priv->proximity &&
+                  proximity_sensor_enabled &&
+                  phosh_proximity_has_fader (priv->proximity);
   if (use_top_layer)
     goto set_layer;
 


### PR DESCRIPTION
The proximity sensor on Miatoll devices is not functioning properly:
  - On my test device, it freezes if monitoring starts while the sensor is covered.
  - On my main device, it freezes regardless.

These two patches provide a workaround to disable the proximity sensor:
   -  When a call is answered, the device screen is turned off.
   -  When the screen is turned back on, we ensure the Call UI is displayed if the call is still active.

This patch also works on devices without sensors.

I will submit these patches upstream.