### PR TITLE
shell: Blank the screen instead of using a fader for calls

### DIFF
--- a/src/proximity.c
+++ b/src/proximity.c
@@ -9,7 +9,6 @@
 #define G_LOG_DOMAIN "phosh-proximity"
 
 #include "phosh-config.h"
-#include "fader.h"
 #include "proximity.h"
 #include "shell.h"
 #include "sensor-proxy-manager.h"
@@ -29,7 +28,7 @@ enum {
   PROP_0,
   PROP_SENSOR_PROXY_MANAGER,
   PROP_CALLS_MANAGER,
-  PROP_FADER,
+  PROP_NEAR,
   LAST_PROP,
 };
 static GParamSpec *props[LAST_PROP];
@@ -41,37 +40,10 @@ typedef struct _PhoshProximity {
   gboolean claimed;
   PhoshSensorProxyManager *sensor_proxy_manager;
   PhoshCallsManager *calls_manager;
-  PhoshFader *fader;
+  gboolean near;
 } PhoshProximity;
 
 G_DEFINE_TYPE (PhoshProximity, phosh_proximity, G_TYPE_OBJECT);
-
-
-static void
-show_fader (PhoshProximity *self, PhoshMonitor *monitor)
-{
-  if (self->fader)
-    return;
-
-  self->fader = g_object_new (PHOSH_TYPE_FADER,
-                              "monitor", monitor,
-                              "style-class", "phosh-fader-proximity-fade",
-                              NULL);
-  gtk_widget_show (GTK_WIDGET (self->fader));
-
-  g_object_notify_by_pspec (G_OBJECT (self), props[PROP_FADER]);
-}
-
-
-static void
-hide_fader (PhoshProximity *self)
-{
-  if (self->fader == NULL)
-    return;
-
-  g_clear_pointer (&self->fader, phosh_cp_widget_destroy);
-  g_object_notify_by_pspec (G_OBJECT (self), props[PROP_FADER]);
-}
 
 
 static void
@@ -117,8 +89,8 @@ on_proximity_released (PhoshSensorProxyManager *sensor_proxy_manager,
 
   if (success == FALSE) {
     if (!phosh_async_error_warn (err, "Failed to release proximity sensor")) {
-      /* If not canceled hide fader */
-      hide_fader (self);
+      self->near = FALSE;
+      g_object_notify_by_pspec (G_OBJECT (self), props[PROP_NEAR]);
     }
     return;
   }
@@ -126,7 +98,8 @@ on_proximity_released (PhoshSensorProxyManager *sensor_proxy_manager,
   g_debug ("Released proximity sensor");
   self->claimed = FALSE;
 
-  hide_fader (self);
+  self->near = FALSE;
+  g_object_notify_by_pspec (G_OBJECT (self), props[PROP_NEAR]);
 }
 
 
@@ -165,8 +138,8 @@ on_has_proximity_changed (PhoshProximity          *self,
   g_debug ("Found %s proximity sensor", has_proximity ? "a" : "no");
 
   /* If the proxy went a way we always unclaim but only claim on ongoing calls: */
-  if (!phosh_calls_manager_get_active_call_handle (self->calls_manager) && has_proximity)
-    return;
+  /* if (!phosh_calls_manager_get_active_call_handle (self->calls_manager) && has_proximity) */
+  /*   return; */
 
   phosh_proximity_claim_proximity (self, has_proximity);
 }
@@ -193,21 +166,15 @@ on_proximity_near_changed (PhoshProximity          *self,
                            GParamSpec              *pspec,
                            PhoshSensorProxyManager *sensor)
 {
-  gboolean near;
-  PhoshShell *shell = phosh_shell_get_default ();
-  PhoshMonitor *monitor = phosh_shell_get_builtin_monitor (shell);
-
   if (!self->claimed)
     return;
 
-  near = phosh_dbus_sensor_proxy_get_proximity_near (
+  self->near = phosh_dbus_sensor_proxy_get_proximity_near (
     PHOSH_DBUS_SENSOR_PROXY (self->sensor_proxy_manager));
 
-  g_debug ("Proximity near changed: %d", near);
-  if (near && monitor)
-    show_fader (self, monitor);
-  else
-    hide_fader (self);
+  g_object_notify_by_pspec (G_OBJECT (self), props[PROP_NEAR]);
+
+  g_debug ("Proximity near changed: %d", self->near);
 }
 
 static void
@@ -226,6 +193,10 @@ phosh_proximity_set_property (GObject *object,
     case PROP_CALLS_MANAGER:
       /* construct only */
       self->calls_manager = g_value_dup_object (value);
+      break;
+    case PROP_NEAR:
+      /* construct only */
+      self->near = g_value_get_boolean (value);
       break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
@@ -249,8 +220,8 @@ phosh_proximity_get_property (GObject *object,
   case PROP_CALLS_MANAGER:
     g_value_set_object (value, self->calls_manager);
     break;
-  case PROP_FADER:
-    g_value_set_boolean (value, !!self->fader);
+  case PROP_NEAR:
+    g_value_set_boolean (value, self->near);
     break;
   default:
     G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
@@ -263,6 +234,8 @@ static void
 phosh_proximity_constructed (GObject *object)
 {
   PhoshProximity *self = PHOSH_PROXIMITY (object);
+
+  self->near = FALSE;
 
   g_signal_connect_swapped (self->calls_manager,
                             "notify::active-call",
@@ -303,7 +276,6 @@ phosh_proximity_dispose (GObject *object)
      g_clear_object (&self->calls_manager);
   }
 
-  g_clear_pointer (&self->fader, phosh_cp_widget_destroy);
   G_OBJECT_CLASS (phosh_proximity_parent_class)->dispose (object);
 }
 
@@ -335,15 +307,13 @@ phosh_proximity_class_init (PhoshProximityClass *klass)
       PHOSH_TYPE_CALLS_MANAGER,
       G_PARAM_CONSTRUCT_ONLY | G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 
-  /* PhoshProximity:fader:
-   *
-   * %TRUE if the fader to prevent accidental user input is currently active
-   */
-  props[PROP_FADER] =
+  props[PROP_NEAR] =
     g_param_spec_boolean (
-      "fader", "", "",
+      "near",
+      "near",
+      "Proximity sensor state is near",
       FALSE,
-      G_PARAM_READABLE | G_PARAM_EXPLICIT_NOTIFY | G_PARAM_STATIC_STRINGS);
+      G_PARAM_READWRITE | G_PARAM_EXPLICIT_NOTIFY | G_PARAM_STATIC_STRINGS);
 
   g_object_class_install_properties (object_class, LAST_PROP, props);
 
@@ -363,13 +333,14 @@ phosh_proximity_new (PhoshSensorProxyManager *sensor_proxy_manager,
   return g_object_new (PHOSH_TYPE_PROXIMITY,
                        "sensor-proxy-manager", sensor_proxy_manager,
                        "calls-manager", calls_manager,
+                       "near", FALSE,
                        NULL);
 }
 
 gboolean
-phosh_proximity_has_fader (PhoshProximity *self)
+phosh_proximity_near (PhoshProximity *self)
 {
   g_return_val_if_fail (PHOSH_IS_PROXIMITY (self), FALSE);
 
-  return !!self->fader;
+  return self->near;
 }

--- a/src/proximity.h
+++ b/src/proximity.h
@@ -17,6 +17,6 @@ G_DECLARE_FINAL_TYPE (PhoshProximity, phosh_proximity, PHOSH, PROXIMITY, GObject
 
 PhoshProximity *phosh_proximity_new (PhoshSensorProxyManager *sensor_proxy_manager,
                                      PhoshCallsManager       *calls_manager);
-gboolean        phosh_proximity_has_fader (PhoshProximity *sensor_proxy_manager);
+gboolean        phosh_proximity_near (PhoshProximity *sensor_proxy_manager);
 
 G_END_DECLS

--- a/src/screen-saver-manager.c
+++ b/src/screen-saver-manager.c
@@ -86,6 +86,7 @@ typedef struct _PhoshScreenSaverManager
   GSettings *settings;
   gboolean lock_enabled;
   gboolean lock_delay;
+  gboolean suspend_autolock;
   guint    lock_delay_timer_id;
   int      inhibit_pwr_btn_fd;
   int      inhibit_suspend_fd;
@@ -160,10 +161,11 @@ arm_lock_delay_timer (PhoshScreenSaverManager *self, gboolean active, gboolean l
 static void
 screen_saver_set_active (PhoshScreenSaverManager *self, gboolean active, gboolean lock)
 {
+
   if (self->active == active)
     return;
 
-  g_debug ("Activating screen saver: %d, lock: %d, lock_delay: %d", active, lock,
+  g_warning ("Activating screen saver: %d, lock: %d, lock_delay: %d", active, lock,
     self->lock_delay);
 
   /* on_primary_monitor_power_mode_changed will update self->active once the power mode is set  */
@@ -819,7 +821,7 @@ on_primary_monitor_power_mode_changed (PhoshScreenSaverManager *self,
     notify_active_changed (self);
   }
 
-  if (active) {
+  if (active && !self->suspend_autolock) {
     arm_lock_delay_timer (self, active, self->lock_enabled);
   } else {
     unarm_lock_delay_timer (self, "power mode change");
@@ -1005,6 +1007,7 @@ phosh_screen_saver_manager_init (PhoshScreenSaverManager *self)
   self->cancel = g_cancellable_new ();
   self->inhibit_suspend_fd = -1;
   self->inhibit_pwr_btn_fd = -1;
+  self->suspend_autolock = FALSE;
 
   g_action_map_add_action_entries (G_ACTION_MAP (phosh_shell_get_default ()),
                                    entries,
@@ -1019,4 +1022,11 @@ phosh_screen_saver_manager_new (PhoshLockscreenManager *lockscreen_manager)
   return g_object_new (PHOSH_TYPE_SCREEN_SAVER_MANAGER,
                        "lockscreen-manager", lockscreen_manager,
                        NULL);
+}
+
+void
+phosh_screen_saver_manager_suspend_autolock (PhoshScreenSaverManager *self,
+                                             gboolean                suspend)
+{
+  self->suspend_autolock = suspend;
 }

--- a/src/screen-saver-manager.h
+++ b/src/screen-saver-manager.h
@@ -22,5 +22,7 @@ G_DECLARE_FINAL_TYPE (PhoshScreenSaverManager, phosh_screen_saver_manager, PHOSH
                       PhoshDBusScreenSaverSkeleton)
 
 PhoshScreenSaverManager *phosh_screen_saver_manager_new (PhoshLockscreenManager *lockscreen_manager);
+void phosh_screen_saver_manager_suspend_autolock        (PhoshScreenSaverManager *self,
+                                                         gboolean                 suspend);
 
 G_END_DECLS

--- a/src/shell.c
+++ b/src/shell.c
@@ -241,14 +241,6 @@ update_top_level_layer (PhoshShell *self)
   g_return_if_fail (PHOSH_IS_TOP_PANEL (priv->top_panel));
   state = phosh_shell_get_state (self);
 
-  /* When the proximity fader is on we want to remove the top-panel from the
-     overlay layer since it uses an exclusive zone and hence the fader is
-     drawn below that top-panel. This can be dropped once layer-shell allows
-     to specify the z-level */
-  use_top_layer = priv->proximity && phosh_proximity_has_fader (priv->proximity);
-  if (use_top_layer)
-    goto set_layer;
-
   /* We want the top-bar on the lock screen */
   use_top_layer = !phosh_shell_get_locked (self);
   if (use_top_layer)
@@ -269,9 +261,17 @@ update_top_level_layer (PhoshShell *self)
 
 
 static void
-on_proximity_fader_changed (PhoshShell *self)
+on_proximity_near_changed (PhoshShell *self)
 {
-  update_top_level_layer (self);
+  PhoshShellPrivate *priv;
+  gboolean near;
+
+  g_warning("on_proximity_near_changed");
+  priv = phosh_shell_get_instance_private (self);
+
+  near = phosh_proximity_near (priv->proximity);
+  phosh_screen_saver_manager_suspend_autolock (priv->screen_saver_manager, near);
+  phosh_shell_enable_power_save (phosh_shell_get_default (), near);
 }
 
 
@@ -761,8 +761,8 @@ setup_idle_cb (PhoshShell *self)
                                            priv->calls_manager);
     phosh_monitor_manager_set_sensor_proxy_manager (priv->monitor_manager,
                                                     priv->sensor_proxy_manager);
-    g_signal_connect_swapped (priv->proximity, "notify::fader",
-                              G_CALLBACK (on_proximity_fader_changed), self);
+    g_signal_connect_swapped (priv->proximity, "notify::near",
+                              G_CALLBACK (on_proximity_near_changed), self);
     priv->ambient = phosh_ambient_new (priv->sensor_proxy_manager);
   }
 


### PR DESCRIPTION
Do not merge this, conflicts with my previous proximity patch and I need to enhance my hadess-sensorfwd-proxy pull request before both can be merged.