### PR TITLE
shell: Blank the screen instead of using a fader for calls

### DIFF
--- a/src/proximity.c
+++ b/src/proximity.c
@@ -9,7 +9,6 @@
 #define G_LOG_DOMAIN "phosh-proximity"
 
 #include "phosh-config.h"
-#include "fader.h"
 #include "proximity.h"
 #include "shell-priv.h"
 #include "sensor-proxy-manager.h"
@@ -31,7 +30,7 @@ enum {
   PROP_0,
   PROP_SENSOR_PROXY_MANAGER,
   PROP_CALLS_MANAGER,
-  PROP_FADER,
+  PROP_NEAR,
   LAST_PROP,
 };
 static GParamSpec *props[LAST_PROP];
@@ -44,39 +43,12 @@ typedef struct _PhoshProximity {
   gboolean claimed;
   PhoshSensorProxyManager *sensor_proxy_manager;
   PhoshCallsManager *calls_manager;
-  PhoshFader *fader;
+  gboolean near;
 
   GSettings      *settings;
 } PhoshProximity;
 
 G_DEFINE_TYPE (PhoshProximity, phosh_proximity, G_TYPE_OBJECT);
-
-
-static void
-show_fader (PhoshProximity *self, PhoshMonitor *monitor)
-{
-  if (self->fader)
-    return;
-
-  self->fader = g_object_new (PHOSH_TYPE_FADER,
-                              "monitor", monitor,
-                              "style-class", "phosh-fader-proximity-fade",
-                              NULL);
-  gtk_widget_set_visible (GTK_WIDGET (self->fader), TRUE);
-
-  g_object_notify_by_pspec (G_OBJECT (self), props[PROP_FADER]);
-}
-
-
-static void
-hide_fader (PhoshProximity *self)
-{
-  if (self->fader == NULL)
-    return;
-
-  g_clear_pointer (&self->fader, phosh_cp_widget_destroy);
-  g_object_notify_by_pspec (G_OBJECT (self), props[PROP_FADER]);
-}
 
 
 static void
@@ -122,8 +94,8 @@ on_proximity_released (PhoshSensorProxyManager *sensor_proxy_manager,
 
   if (success == FALSE) {
     if (!phosh_async_error_warn (err, "Failed to release proximity sensor")) {
-      /* If not canceled hide fader */
-      hide_fader (self);
+      self->near = FALSE;
+      g_object_notify_by_pspec (G_OBJECT (self), props[PROP_NEAR]);
     }
     return;
   }
@@ -131,7 +103,8 @@ on_proximity_released (PhoshSensorProxyManager *sensor_proxy_manager,
   g_debug ("Released proximity sensor");
   self->claimed = FALSE;
 
-  hide_fader (self);
+  self->near = FALSE;
+  g_object_notify_by_pspec (G_OBJECT (self), props[PROP_NEAR]);
 }
 
 
@@ -219,21 +192,15 @@ on_proximity_near_changed (PhoshProximity          *self,
                            GParamSpec              *pspec,
                            PhoshSensorProxyManager *sensor)
 {
-  gboolean near;
-  PhoshShell *shell = phosh_shell_get_default ();
-  PhoshMonitor *monitor = phosh_shell_get_builtin_monitor (shell);
-
   if (!self->claimed)
     return;
 
-  near = phosh_dbus_sensor_proxy_get_proximity_near (
+  self->near = phosh_dbus_sensor_proxy_get_proximity_near (
     PHOSH_DBUS_SENSOR_PROXY (self->sensor_proxy_manager));
 
-  g_debug ("Proximity near changed: %d", near);
-  if (near && monitor)
-    show_fader (self, monitor);
-  else
-    hide_fader (self);
+  g_object_notify_by_pspec (G_OBJECT (self), props[PROP_NEAR]);
+
+  g_debug ("Proximity near changed: %d", self->near);
 }
 
 static void
@@ -252,6 +219,10 @@ phosh_proximity_set_property (GObject *object,
     case PROP_CALLS_MANAGER:
       /* construct only */
       self->calls_manager = g_value_dup_object (value);
+      break;
+    case PROP_NEAR:
+      /* construct only */
+      self->near = g_value_get_boolean (value);
       break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
@@ -275,8 +246,8 @@ phosh_proximity_get_property (GObject *object,
   case PROP_CALLS_MANAGER:
     g_value_set_object (value, self->calls_manager);
     break;
-  case PROP_FADER:
-    g_value_set_boolean (value, !!self->fader);
+  case PROP_NEAR:
+    g_value_set_boolean (value, self->near);
     break;
   default:
     G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
@@ -290,6 +261,7 @@ phosh_proximity_constructed (GObject *object)
 {
   PhoshProximity *self = PHOSH_PROXIMITY (object);
 
+  self->near = FALSE;
   self->settings = g_settings_new (PHOSH_SHELL_PROXIMITY_SCHEMA_ID);
 
   g_signal_connect_swapped (self->calls_manager,
@@ -333,7 +305,6 @@ phosh_proximity_dispose (GObject *object)
 
   g_clear_object (&self->settings);
 
-  g_clear_pointer (&self->fader, phosh_cp_widget_destroy);
   G_OBJECT_CLASS (phosh_proximity_parent_class)->dispose (object);
 }
 
@@ -365,15 +336,13 @@ phosh_proximity_class_init (PhoshProximityClass *klass)
       PHOSH_TYPE_CALLS_MANAGER,
       G_PARAM_CONSTRUCT_ONLY | G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 
-  /* PhoshProximity:fader:
-   *
-   * %TRUE if the fader to prevent accidental user input is currently active
-   */
-  props[PROP_FADER] =
+  props[PROP_NEAR] =
     g_param_spec_boolean (
-      "fader", "", "",
+      "near",
+      "near",
+      "Proximity sensor state is near",
       FALSE,
-      G_PARAM_READABLE | G_PARAM_EXPLICIT_NOTIFY | G_PARAM_STATIC_STRINGS);
+      G_PARAM_READWRITE | G_PARAM_EXPLICIT_NOTIFY | G_PARAM_STATIC_STRINGS);
 
   g_object_class_install_properties (object_class, LAST_PROP, props);
 
@@ -393,15 +362,16 @@ phosh_proximity_new (PhoshSensorProxyManager *sensor_proxy_manager,
   return g_object_new (PHOSH_TYPE_PROXIMITY,
                        "sensor-proxy-manager", sensor_proxy_manager,
                        "calls-manager", calls_manager,
+                       "near", FALSE,
                        NULL);
 }
 
 gboolean
-phosh_proximity_has_fader (PhoshProximity *self)
+phosh_proximity_near (PhoshProximity *self)
 {
   g_return_val_if_fail (PHOSH_IS_PROXIMITY (self), FALSE);
 
-  return !!self->fader;
+  return self->near;
 }
 
 gboolean

--- a/src/proximity.h
+++ b/src/proximity.h
@@ -19,7 +19,7 @@ G_DECLARE_FINAL_TYPE (PhoshProximity, phosh_proximity, PHOSH, PROXIMITY, GObject
 
 PhoshProximity *phosh_proximity_new (PhoshSensorProxyManager *sensor_proxy_manager,
                                      PhoshCallsManager       *calls_manager);
-gboolean        phosh_proximity_has_fader (PhoshProximity *sensor_proxy_manager);
 gboolean        phosh_proximity_sensor_enabled (PhoshProximity *sensor_proxy_manager);
+gboolean        phosh_proximity_near (PhoshProximity *sensor_proxy_manager);
 
 G_END_DECLS

--- a/src/shell.c
+++ b/src/shell.c
@@ -236,7 +236,6 @@ update_top_level_layer (PhoshShell *self)
   PhoshShellPrivate *priv;
   guint32 layer, current;
   gboolean use_top_layer;
-  gboolean proximity_sensor_enabled;
 
   g_return_if_fail (PHOSH_IS_SHELL (self));
   priv = phosh_shell_get_instance_private (self);
@@ -244,20 +243,8 @@ update_top_level_layer (PhoshShell *self)
   if (priv->top_panel == NULL)
     return;
 
-  proximity_sensor_enabled = phosh_proximity_sensor_enabled (priv->proximity);
-
   g_return_if_fail (PHOSH_IS_TOP_PANEL (priv->top_panel));
   state = phosh_shell_get_state (self);
-
-  /* When the proximity fader is on we want to remove the top-panel from the
-     overlay layer since it uses an exclusive zone and hence the fader is
-     drawn below that top-panel. This can be dropped once layer-shell allows
-     to specify the z-level */
-  use_top_layer = priv->proximity &&
-                  proximity_sensor_enabled &&
-                  phosh_proximity_has_fader (priv->proximity);
-  if (use_top_layer)
-    goto set_layer;
 
   /* We want the top-bar on the lock screen */
   use_top_layer = !phosh_shell_get_locked (self);
@@ -279,9 +266,15 @@ update_top_level_layer (PhoshShell *self)
 
 
 static void
-on_proximity_fader_changed (PhoshShell *self)
+on_proximity_near_changed (PhoshShell *self)
 {
-  update_top_level_layer (self);
+  PhoshShellPrivate *priv;
+  gboolean near;
+
+  priv = phosh_shell_get_instance_private (self);
+
+  near = phosh_proximity_near (priv->proximity);
+  phosh_shell_enable_power_save (phosh_shell_get_default (), near);
 }
 
 
@@ -799,8 +792,8 @@ setup_idle_cb (PhoshShell *self)
                                            priv->calls_manager);
     phosh_monitor_manager_set_sensor_proxy_manager (priv->monitor_manager,
                                                     priv->sensor_proxy_manager);
-    g_signal_connect_swapped (priv->proximity, "notify::fader",
-                              G_CALLBACK (on_proximity_fader_changed), self);
+    g_signal_connect_swapped (priv->proximity, "notify::near",
+                              G_CALLBACK (on_proximity_near_changed), self);
     priv->ambient = phosh_ambient_new (priv->sensor_proxy_manager);
   }
 


### PR DESCRIPTION
When accepting a call, if the proximity sensor returns a "near" state, immediately blank the screen instead of using a fader.